### PR TITLE
ci(workflows): 更新 Node.js 设置至 v5 并移除缓存配置

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -15,11 +15,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
-          cache: "pnpm"
-          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
移除不再需要的 pnpm 缓存配置，同时将 actions/setup-node 从 v3 升级至 v5 以使用最新功能