### PR TITLE
build: 使用 --frozen-lockfile 选项安装依赖

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN npm install -g pnpm
 COPY . .
 
 # 安装依赖
-RUN pnpm install
+RUN pnpm install --frozen-lockfile
 
 # 暴露端口
 EXPOSE 8083


### PR DESCRIPTION
确保依赖安装时严格使用 lockfile 中的版本，避免潜在的版本不一致问题